### PR TITLE
Cloud Foundry forward-compatibility

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -9,4 +9,4 @@ echo "------- load data ------"
 python abb/manage.py loaddata hours/fixtures/initial_data.json
 
 echo "------ starting django &nbsp;------"
-cd abb && waitress-serve --port=$VCAP_APP_PORT abb.wsgi:application
+cd abb && waitress-serve --port=$PORT abb.wsgi:application


### PR DESCRIPTION
Per [Cloud Foundry documentation](https://docs.cloudfoundry.org/running/apps-enable-diego.html#app-code) use of `$VCAP_APP_HOST` and `$VCAP_APP_PASSWORD` are incompatible with newer (Diego-based) Cloud Foundry deployments. This change makes this repository forward compatible with the new cloud.gov environment deployment in AWS GovCloud.
